### PR TITLE
HTTP headers spec in task

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ List of config fields:
 * `pullInterval` time duration spec in Go-flavoured duration syntax. Cannot be negative or less than "1s". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 * `observationSource` - pipeline spec in DOT Syntax
 
+Notes on changes:
+
+* `http` task has been changed from the Chainlink's reference, to skip `allowUnrestrictedNetworkAccess` option, since TOMLs are trusted in this context. Added ability to specify additional HTTP headers, since some price fetching APIs require authorization – `headersMap`. Usage: `headersMap="{\\"x-api-key\\": \\"foobar\\"}"`
+
 ### Native Go code
 
 Yes, you can also simply fork this repo and add own native implementations of the price feeds. There is a Binance example provided in [feed_binance.go](/oracle/feed_binance.go). Any complex feed can be added as long as the implementation follows this Go interface:

--- a/pipeline/common_http.go
+++ b/pipeline/common_http.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -19,6 +20,7 @@ func makeHTTPRequest(
 	method StringParam,
 	url URLParam,
 	requestData MapParam,
+	headerMap MapParam,
 ) ([]byte, int, http.Header, time.Duration, error) {
 
 	var bodyReader io.Reader
@@ -35,6 +37,15 @@ func makeHTTPRequest(
 		return nil, 0, nil, 0, errors.Wrap(err, "failed to create http.Request")
 	}
 	request.Header.Set("Content-Type", "application/json")
+
+	for key, value := range headerMap {
+		if strings.ToLower(key) == lowerContentTypeKey {
+			// skip Content-Type override attempts
+			continue
+		}
+
+		request.Header.Set(key, value.(string))
+	}
 
 	httpRequest := HTTPRequest{
 		Request: request,
@@ -60,6 +71,8 @@ func makeHTTPRequest(
 	}
 	return responseBytes, statusCode, headers, elapsed, nil
 }
+
+var lowerContentTypeKey = strings.ToLower("Content-Type")
 
 type PossibleErrorResponses struct {
 	Error        string `json:"error"`


### PR DESCRIPTION
Added ability to specify additional HTTP headers, since some price fetching APIs require authorization – `headersMap`. 

**Usage:**
```
headersMap="{\\"x-api-key\\": \\"foobar\\"}"
```

(escaping is needed as it's a JSON mapping inside TOML string)

