### PR TITLE
feat/height in logs

### DIFF
--- a/oracle/service.go
+++ b/oracle/service.go
@@ -366,7 +366,9 @@ func (s *oracleSvc) commitSetPrices(dataC <-chan *PriceData) {
 
 				return
 			}
-			batchLog.WithField("hash", txResp.TxResponse.TxHash).Infoln("sent Tx in", time.Since(ts))
+			batchLog.WithField("height", txResp.TxResponse.Height).
+				WithField("hash", txResp.TxResponse.TxHash).
+				Infoln("sent Tx in", time.Since(ts))
 		}
 	}
 


### PR DESCRIPTION
Add height in logs when running price-oracle for better debugging

logs e.g.

```
INFO[0000] waiting for GRPC services
INFO[0001] found 1 stork feed configs
INFO[0001] Connected to WebSocket server
INFO[0001] Connected to stork websocket
INFO[0001] initialized 1 price pullers                   svc=oracle
INFO[0001] starting pullers for 1 feeds                  svc=oracle
INFO[0012] sent Tx in 527.83678ms                        batch_size=1 hash=D8D8EF7F2BE7259DFBC359D3DEB73CA229EC134407AD533CAB1266A272BCBE32 height=416 svc=oracle timeout=true
INFO[0072] sent Tx in 625.759718ms                       batch_size=1 hash=75296652B3C89F5C56E7AF9ED9856AD6D5E6A2F0BB54DB7342006B1D83CF11BF height=560 svc=oracle timeout=true
INFO[0132] sent Tx in 628.234486ms                       batch_size=1 hash=3CC81D2204592AFC7E13BFDA12F724A2D7D92A8B24EF33F93C5CE12547A925B2 height=703 svc=oracle timeout=true
INFO[0192] sent Tx in 322.055554ms                       batch_size=1 hash=1FAC894255FF99B7EE28BE2B1B491977793E09EC488FB9CA318F4EA5C3BFCD48 height=844 svc=oracle timeout=true
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced logging functionality for transaction processing to include both transaction height and hash, providing better contextual information for traceability and debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->