### PR TITLE
feat: add back go mod download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN rm ./architecture
 WORKDIR /src
 COPY go.mod .
 COPY go.sum .
-RUN go mod tidy
+RUN go mod download
 COPY . .
 #install binary
 RUN make install


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated dependency management in Dockerfile to use `go mod download` instead of `go mod tidy`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->