### PR TITLE
chore: add ORACLE_NETWORK_NODE to web2Provider testnet

### DIFF
--- a/helm/values.testnet.yaml
+++ b/helm/values.testnet.yaml
@@ -157,6 +157,7 @@ oracle:
       env:
         chain:
           chainId: injective-888
+          networkNode: "testnet,lb"
           gasPrices: 1600000000inj
           gasAdjust: "1.1"
           serviceWaitTimeout: 1m


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testnet environment configuration to specify network node settings for Chainlink and web2-provider services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->