### PR TITLE
feat(helm): add W8 USDC equity feeds

### DIFF
--- a/helm/values.mainnet.eu.yaml
+++ b/helm/values.mainnet.eu.yaml
@@ -399,6 +399,28 @@ oracle:
             MSTRUUSDTPrice [type="divide" input="$(feedParse2)" divisor="$(usdtParse)" precision=6]
             MSTRUUSDTPrice
           """
+      - name: MSTR_USDC.tpl
+        content: |
+          provider = "InjectiveLabs"
+          ticker = "MSTR/USDC"
+          pullInterval = "5s"
+          oracleType = "Provider"
+          observationSource = """
+            feed [type=http
+                    method=GET
+                    url="https://fast-api.mainnet.seda.xyz/execute?execProgramId=ad880830f3d6a46024715640b1ffd80a373f61008003aaefbbdded06cd27e5ad&execInputs=%7B%22session_ids%22%3A%5B%220x1a11eb21c271f3127e4c9ec8a0e9b1042dc088ccba7a94a1a7d1aa37599a00f6%22%2C%220xe1e80251e5f5184f2195008382538e847fafc36f751896889dd3d1b1f6111f09%22%2C%220xd8b856d7e17c467877d2d947f27b832db0d65b362ddb6f728797d46b0a8b54c0%22%2C%220xc3055f49e1dc863a7f24d9b83e86fe10d7d16fb583bc6445505b01d230e0d647%22%5D%2C%22weights%22%3A%5B100%2C100%2C100%2C100%5D%7D&includeDebugInfo=true&encoding=utf8&injectLastResult=success"
+                    headerMap="{\\"Authorization\\": \\"Bearer $SEDA_API_KEY\\", \\"Content-Type\\": \\"application/json\\"}"];
+            feedParse1 [type="jsonparse" path="data,result"]
+            feedParse2 [type="jsonparse" path="composite_rate"]
+            feed -> feedParse1 -> feedParse2
+
+            usdc [type=http method=GET url="https://k8s.mainnet.asset.injective.network/asset-price/v1/prices?denoms=erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a"];
+            usdcParse [type="jsonparse" path="erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a"]
+            usdc -> usdcParse
+
+            MSTRUSDCPrice [type="divide" input="$(feedParse2)" divisor="$(usdcParse)" precision=6]
+            MSTRUSDCPrice
+          """
 
       - name: NVDA.tpl
         content: |

--- a/helm/values.mainnet.eu.yaml
+++ b/helm/values.mainnet.eu.yaml
@@ -223,6 +223,28 @@ oracle:
             GOOGLUSDTPrice [type="divide" input="$(feedParse2)" divisor="$(usdtParse)" precision=6]
             GOOGLUSDTPrice
           """
+      - name: GOOGL_USDC.tpl
+        content: |
+          provider = "InjectiveLabs"
+          ticker = "GOOGL/USDC"
+          pullInterval = "5s"
+          oracleType = "Provider"
+          observationSource = """
+            feed [type=http
+                    method=GET
+                    url="https://fast-api.mainnet.seda.xyz/execute?execProgramId=ad880830f3d6a46024715640b1ffd80a373f61008003aaefbbdded06cd27e5ad&execInputs=%7B%22session_ids%22%3A%5B%220x43c3a42db1a663a22551d6c35d5bab823e86c1a05f27de3dd900e68952fce175%22%2C%220x5a48c03e9b9cb337801073ed9d166817473697efff0d138874e0f6a33d6d5aa6%22%2C%220x88d0800b1649d98e21b8bf9c3f42ab548034d62874ad5d80e1c1b730566d7f61%22%2C%220x07d24bb76843496a45bce0add8b51555f2ea02098cb04f4c6d61f7b5720836b4%22%5D%2C%22weights%22%3A%5B100%2C100%2C100%2C100%5D%7D&includeDebugInfo=true&encoding=utf8&injectLastResult=success"
+                    headerMap="{\\"Authorization\\": \\"Bearer $SEDA_API_KEY\\", \\"Content-Type\\": \\"application/json\\"}"];
+            feedParse1 [type="jsonparse" path="data,result"]
+            feedParse2 [type="jsonparse" path="composite_rate"]
+            feed -> feedParse1 -> feedParse2
+
+            usdc [type=http method=GET url="https://k8s.mainnet.asset.injective.network/asset-price/v1/prices?denoms=erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a"];
+            usdcParse [type="jsonparse" path="erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a"]
+            usdc -> usdcParse
+
+            GOOGLUSDCPrice [type="divide" input="$(feedParse2)" divisor="$(usdcParse)" precision=6]
+            GOOGLUSDCPrice
+          """
       - name: HOOD.tpl
         content: |
           provider = "InjectiveLabs"

--- a/helm/values.mainnet.eu.yaml
+++ b/helm/values.mainnet.eu.yaml
@@ -201,6 +201,28 @@ oracle:
             CRCLUSDTPrice [type="divide" input="$(feedParse2)" divisor="$(usdtParse)" precision=6]
             CRCLUSDTPrice
           """
+      - name: CRCL_USDC.tpl
+        content: |
+          provider = "InjectiveLabs"
+          ticker = "CRCL/USDC"
+          pullInterval = "5s"
+          oracleType = "Provider"
+          observationSource = """
+            feed [type=http
+                    method=GET
+                    url="https://fast-api.mainnet.seda.xyz/execute?execProgramId=ad880830f3d6a46024715640b1ffd80a373f61008003aaefbbdded06cd27e5ad&execInputs=%7B%22session_ids%22%3A%5B%220xb6ce1644a22bb348f89a81696141c1caaca5e7ea83de289a44fba1a9897ca2d6%22%2C%220x92b8527aabe59ea2b12230f7b532769b133ffb118dfbd48ff676f14b273f1365%22%2C%220x9bdba52fbb3d588d573928b1e781c6441e446a83c011fed92d8362c5b309ce02%22%2C%220x63cc3973d36735f8b1725f1069a7ddee200db1570573674da916282fde15dd0e%22%5D%2C%22weights%22%3A%5B100%2C100%2C100%2C100%5D%7D&includeDebugInfo=true&encoding=utf8&injectLastResult=success"
+                    headerMap="{\\"Authorization\\": \\"Bearer $SEDA_API_KEY\\", \\"Content-Type\\": \\"application/json\\"}"];
+            feedParse1 [type="jsonparse" path="data,result"]
+            feedParse2 [type="jsonparse" path="composite_rate"]
+            feed -> feedParse1 -> feedParse2
+
+            usdc [type=http method=GET url="https://k8s.mainnet.asset.injective.network/asset-price/v1/prices?denoms=erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a"];
+            usdcParse [type="jsonparse" path="erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a"]
+            usdc -> usdcParse
+
+            CRCLUSDCPrice [type="divide" input="$(feedParse2)" divisor="$(usdcParse)" precision=6]
+            CRCLUSDCPrice
+          """
       - name: GOOGL.tpl
         content: |
           provider = "InjectiveLabs"

--- a/helm/values.mainnet.eu.yaml
+++ b/helm/values.mainnet.eu.yaml
@@ -553,6 +553,28 @@ oracle:
             TSLAUSDTPrice [type="divide" input="$(feedParse2)" divisor="$(usdtParse)" precision=6]
             TSLAUSDTPrice
           """
+      - name: TSLA_USDC.tpl
+        content: |
+          provider = "InjectiveLabs"
+          ticker = "TSLA/USDC"
+          pullInterval = "5s"
+          oracleType = "Provider"
+          observationSource = """
+            feed [type=http
+                    method=GET
+                    url="https://fast-api.mainnet.seda.xyz/execute?execProgramId=ad880830f3d6a46024715640b1ffd80a373f61008003aaefbbdded06cd27e5ad&execInputs=%7B%22session_ids%22%3A%5B%220x42676a595d0099c381687124805c8bb22c75424dffcaa55e3dc6549854ebe20a%22%2C%220x16dad506d7db8da01c87581c87ca897a012a153557d4d578c3b9c9e1bc0632f1%22%2C%220x2a797e196973b72447e0ab8e841d9f5706c37dc581fe66a0bd21bcd256cdb9b9%22%2C%220x713631e41c06db404e6a5d029f3eebfd5b885c59dce4a19f337c024e26584e26%22%5D%2C%22weights%22%3A%5B100%2C100%2C100%2C100%5D%7D&includeDebugInfo=true&encoding=utf8&injectLastResult=success"
+                    headerMap="{\\"Authorization\\": \\"Bearer $SEDA_API_KEY\\", \\"Content-Type\\": \\"application/json\\"}"];
+            feedParse1 [type="jsonparse" path="data,result"]
+            feedParse2 [type="jsonparse" path="composite_rate"]
+            feed -> feedParse1 -> feedParse2
+
+            usdc [type=http method=GET url="https://k8s.mainnet.asset.injective.network/asset-price/v1/prices?denoms=erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a"];
+            usdcParse [type="jsonparse" path="erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a"]
+            usdc -> usdcParse
+
+            TSLAUSDCPrice [type="divide" input="$(feedParse2)" divisor="$(usdcParse)" precision=6]
+            TSLAUSDCPrice
+          """
       - name: TTI.tpl
         content: |
           provider = "InjectiveLabs"

--- a/helm/values.mainnet.eu.yaml
+++ b/helm/values.mainnet.eu.yaml
@@ -487,6 +487,28 @@ oracle:
             PLTRUSDTPrice [type="divide" input="$(feedParse2)" divisor="$(usdtParse)" precision=6]
             PLTRUSDTPrice
           """
+      - name: PLTR_USDC.tpl
+        content: |
+          provider = "InjectiveLabs"
+          ticker = "PLTR/USDC"
+          pullInterval = "5s"
+          oracleType = "Provider"
+          observationSource = """
+            feed [type=http
+                    method=GET
+                    url="https://fast-api.mainnet.seda.xyz/execute?execProgramId=ad880830f3d6a46024715640b1ffd80a373f61008003aaefbbdded06cd27e5ad&execInputs=%7B%22session_ids%22%3A%5B%220xbd8a8e449278ad0b6512695b1c558f816309f045d4e3da21dfc19448281840e8%22%2C%220x11a70634863ddffb71f2b11f2cff29f73f3db8f6d0b78c49f2b5f4ad36e885f0%22%2C%220xb11610f59456057d9bc82b0795c6d7aea6e2e075fc3e1991abc05e2b2861abb2%22%2C%220x3a4c922ec7e8cd86a6fa4005827e723a134a16f4ffe836eac91e7820c61f75a1%22%5D%2C%22weights%22%3A%5B100%2C100%2C100%2C100%5D%7D&includeDebugInfo=true&encoding=utf8&injectLastResult=success"
+                    headerMap="{\\"Authorization\\": \\"Bearer $SEDA_API_KEY\\", \\"Content-Type\\": \\"application/json\\"}"];
+            feedParse1 [type="jsonparse" path="data,result"]
+            feedParse2 [type="jsonparse" path="composite_rate"]
+            feed -> feedParse1 -> feedParse2
+
+            usdc [type=http method=GET url="https://k8s.mainnet.asset.injective.network/asset-price/v1/prices?denoms=erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a"];
+            usdcParse [type="jsonparse" path="erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a"]
+            usdc -> usdcParse
+
+            PLTRUSDCPrice [type="divide" input="$(feedParse2)" divisor="$(usdcParse)" precision=6]
+            PLTRUSDCPrice
+          """
       - name: SPACEX.tpl
         content: |
           provider = "InjectiveLabs"


### PR DESCRIPTION
## Summary
- add USDC-denominated SEDA feed templates for GOOGL, TSLA, PLTR, MSTR, and CRCL
- keep the existing USDT templates unchanged and reuse each base asset's existing SEDA fast-api endpoint
- use the same mainnet USDC price denom lookup and parsing pattern as the existing USDC feeds

## Validation
- parsed `helm/values.mainnet.eu.yaml` with Ruby YAML loader
- verified all 5 new USDC feeds reuse the matching USDT SEDA URL and include the expected USDC denom
- `helm template price-oracle ./helm -f helm/values.mainnet.eu.yaml` was not run because `helm` is not installed in this environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added oracle price feed configurations for five new asset pairs denominated in USDC: CRCL/USDC, GOOGL/USDC, MSTR/USDC, PLTR/USDC, and TSLA/USDC. These feeds are now available on the mainnet EU environment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InjectiveLabs/injective-price-oracle/pull/68?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->